### PR TITLE
Proposed changes..

### DIFF
--- a/common/src/main/java/javax/xml/bind/annotation/adapters/CollapsedStringAdapter.java
+++ b/common/src/main/java/javax/xml/bind/annotation/adapters/CollapsedStringAdapter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javax.xml.bind.annotation.adapters;
+
+/**
+ * Built-in {@link XmlAdapter} to handle <tt>xs:token and its derived types.
+ *
+ * <p>This adapter removes leading and trailing whitespaces, then truncate any sequnce of tab, CR,
+ * LF, and SP by a single whitespace character ' '.
+ *
+ * @author Kohsuke Kawaguchi
+ * @since JAXB 2.0
+ */
+public class CollapsedStringAdapter extends XmlAdapter<String, String> {
+  /**
+   * Removes leading and trailing whitespaces of the string given as the parameter, then truncate
+   * any sequnce of tab, CR, LF, and SP by a single whitespace character ' '.
+   */
+  public String unmarshal(String text) {
+    if (text == null) return null; // be defensive
+
+    int len = text.length();
+
+    // most of the texts are already in the collapsed form.
+    // so look for the first whitespace in the hope that we will
+    // never see it.
+    int s = 0;
+    while (s < len) {
+      if (isWhiteSpace(text.charAt(s))) break;
+      s++;
+    }
+    if (s == len)
+      // the input happens to be already collapsed.
+      return text;
+
+    // we now know that the input contains spaces.
+    // let's sit down and do the collapsing normally.
+
+    StringBuilder result = new StringBuilder(len /*allocate enough size to avoid re-allocation*/);
+
+    if (s != 0) {
+      for (int i = 0; i < s; i++) result.append(text.charAt(i));
+      result.append(' ');
+    }
+
+    boolean inStripMode = true;
+    for (int i = s + 1; i < len; i++) {
+      char ch = text.charAt(i);
+      boolean b = isWhiteSpace(ch);
+      if (inStripMode && b) continue; // skip this character
+
+      inStripMode = b;
+      if (inStripMode) result.append(' ');
+      else result.append(ch);
+    }
+
+    // remove trailing whitespaces
+    len = result.length();
+    if (len > 0 && result.charAt(len - 1) == ' ') result.setLength(len - 1);
+    // whitespaces are already collapsed,
+    // so all we have to do is to remove the last one character
+    // if it's a whitespace.
+
+    return result.toString();
+  }
+
+  /**
+   * No-op.
+   *
+   * <p>Just return the same string given as the parameter.
+   */
+  public String marshal(String s) {
+    return s;
+  }
+
+  /** returns true if the specified char is a white space character. */
+  protected static boolean isWhiteSpace(char ch) {
+    // most of the characters are non-control characters.
+    // so check that first to quickly return false for most of the cases.
+    if (ch > 0x20) return false;
+
+    // other than we have to do four comparisons.
+    return ch == 0x9 || ch == 0xA || ch == 0xD || ch == 0x20;
+  }
+}

--- a/processor/src/main/java/org/treblereel/gwt/xml/mapper/apt/TypeUtils.java
+++ b/processor/src/main/java/org/treblereel/gwt/xml/mapper/apt/TypeUtils.java
@@ -443,11 +443,17 @@ public class TypeUtils {
                                             .toString()
                                             .equals("name")) {
                                           name = entry.getValue().getValue().toString();
-                                        } else {
+                                        } else if (entry
+                                            .getKey()
+                                            .getSimpleName()
+                                            .toString()
+                                            .equals("type")) {
                                           value = (TypeMirror) entry.getValue().getValue();
                                         }
                                       }
-                                      map.put(name, value);
+                                      if (name != null && value != null) {
+                                        map.put(name, value);
+                                      }
                                       return null;
                                     }
                                   }.visit(annotationValue, map);

--- a/processor/src/main/java/org/treblereel/gwt/xml/mapper/apt/definition/BeanDefinition.java
+++ b/processor/src/main/java/org/treblereel/gwt/xml/mapper/apt/definition/BeanDefinition.java
@@ -104,7 +104,7 @@ public class BeanDefinition extends Definition {
 
     Stream<PropertyDefinition> stream = getPropertyDefinitionAsStream(isAnnotated);
 
-    if (xmlType == null || xmlType.propOrder() == null) {
+    if (xmlType == null || Arrays.stream(xmlType.propOrder()).allMatch(p -> p.equals(""))) {
       stream.forEach(elm -> fields.add(elm));
     } else {
       Set<String> propOrder = new LinkedHashSet<>(Arrays.asList(xmlType.propOrder()));
@@ -113,6 +113,12 @@ public class BeanDefinition extends Definition {
       for (String s : propOrder) {
         if (temp.containsKey(s)) {
           fields.add(temp.get(s));
+        } else if (temp.values().stream()
+            .anyMatch(p -> p.getProperty().getSimpleName().toString().equals(s))) {
+          temp.entrySet().stream()
+              .filter(e -> e.getValue().getProperty().getSimpleName().toString().equals(s))
+              .findFirst()
+              .ifPresent(e -> fields.add(e.getValue()));
         } else {
           throw new GenerationException(
               "Property "


### PR DESCRIPTION
`TypeUtils.java`

1) Explicit check for name **AND type**

`BeanDefinition.java`

2) Fix for `xmlType.propOrder` always returning `[""]` by default.

3) Proposed fix for this type of XSD construct:
```
@XmlType(name = "", propOrder = {
    "extension",
    "sequenceReference",
    "time"
})
@XmlRootElement(name = "ConsequentSequence")
public class ConsequentSequence {

    @XmlElement(name = "Extension")
    protected List<Extension> extension;
    @XmlElement(name = "SequenceReference", required = true)
    protected SequenceReference sequenceReference;
    @XmlElement(name = "Time")
    protected Time time;
...
```
Where the `XMLElement` name looked up by `PropertyDefinition.getPropertyName()` does not match the `propOrder` names. In this scenario I check whether the Java property name matches the propOrder entry.. IDK if you can think of a better approach?