### PR TITLE
KOGITO-5668: Codegen should use (un)marshallers for XmlElement(Ref) type: Collections

### DIFF
--- a/processor/src/main/java/org/treblereel/gwt/xml/mapper/apt/definition/ArrayBeanFieldDefinition.java
+++ b/processor/src/main/java/org/treblereel/gwt/xml/mapper/apt/definition/ArrayBeanFieldDefinition.java
@@ -46,18 +46,19 @@ public class ArrayBeanFieldDefinition extends FieldDefinition {
     cu.addImport(ArrayXMLDeserializer.class);
 
     ArrayType array = (ArrayType) bean;
-    TypeMirror componentType = array.getComponentType();
+    TypeMirror componentType =
+        context.getTypeUtils().getTypeMirror(field).orElse(array.getComponentType());
     String arrayType = componentType.toString();
-    if (array.getComponentType().getKind().isPrimitive()) {
+    if (componentType.getKind().isPrimitive()) {
       arrayType =
           context
               .getProcessingEnv()
               .getTypeUtils()
-              .boxedClass((PrimitiveType) array.getComponentType())
+              .boxedClass((PrimitiveType) componentType)
               .getSimpleName()
               .toString();
-    } else if (array.getComponentType().getKind().equals(TypeKind.ARRAY)) {
-      ArrayType array2d = (ArrayType) array.getComponentType();
+    } else if (componentType.getKind().equals(TypeKind.ARRAY)) {
+      ArrayType array2d = (ArrayType) componentType;
       if (array2d.getComponentType().getKind().isPrimitive()) {
         arrayType =
             context
@@ -105,8 +106,7 @@ public class ArrayBeanFieldDefinition extends FieldDefinition {
         field,
         new MethodCallExpr(new NameExpr(ArrayXMLDeserializer.class.getSimpleName()), "newInstance")
             .addArgument(
-                generateXMLDeserializerFactory(
-                    field, array.getComponentType(), array.getComponentType().toString(), cu))
+                generateXMLDeserializerFactory(field, componentType, componentType.toString(), cu))
             .addArgument(
                 new CastExpr()
                     .setType(typeOf)

--- a/processor/src/main/java/org/treblereel/gwt/xml/mapper/apt/definition/FieldDefinition.java
+++ b/processor/src/main/java/org/treblereel/gwt/xml/mapper/apt/definition/FieldDefinition.java
@@ -120,7 +120,8 @@ public abstract class FieldDefinition extends Definition {
     anonymousClassBody.add(method);
 
     Statement expression;
-    if (MoreTypes.asTypeElement(type)
+    TypeMirror typeMirror = typeUtils.getTypeMirror(field).orElse(type);
+    if (MoreTypes.asTypeElement(typeMirror)
         .getModifiers()
         .contains(javax.lang.model.element.Modifier.ABSTRACT)) {
       if (context
@@ -222,7 +223,8 @@ public abstract class FieldDefinition extends Definition {
     anonymousClassBody.add(method);
 
     Statement defaultReturn;
-    if (MoreTypes.asTypeElement(type)
+    TypeMirror typeMirror = typeUtils.getTypeMirror(field).orElse(type);
+    if (MoreTypes.asTypeElement(typeMirror)
         .getModifiers()
         .contains(javax.lang.model.element.Modifier.ABSTRACT)) {
       if (context
@@ -240,7 +242,9 @@ public abstract class FieldDefinition extends Definition {
     } else {
       defaultReturn =
           new ReturnStmt(
-              propertyDefinitionFactory.getFieldDefinition(type).getFieldSerializer(null, cu));
+              propertyDefinitionFactory
+                  .getFieldDefinition(typeMirror)
+                  .getFieldSerializer(null, cu));
     }
 
     method.getBody().ifPresent(body -> body.addAndGetStatement(defaultReturn));

--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmlelementref/interfaces/ITaskTest.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmlelementref/interfaces/ITaskTest.java
@@ -19,6 +19,7 @@ package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmlelementref.int
 import static org.junit.Assert.assertEquals;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.Arrays;
 import javax.xml.stream.XMLStreamException;
 import org.junit.Test;
 
@@ -30,13 +31,31 @@ public class ITaskTest {
   @Test
   public void testSerializeAndDeserializeValue() throws XMLStreamException {
     final String XML =
-        "<?xml version='1.0' encoding='UTF-8'?><tasks><Task1><name>task1Name</name></Task1><task2><name>task2Name</name></task2></tasks>";
-
+        "<?xml version='1.0' encoding='UTF-8'?>"
+            + "<tasks>"
+            + "<Task1><name>task1Name</name></Task1>"
+            + "<task2Ref><name>task2Name</name></task2Ref>"
+            + "<TaskList><name>task3ListName</name></TaskList>"
+            + "<TaskList><name>task4ListName</name></TaskList>"
+            + "<taskListRef><name>task5ListRefName</name></taskListRef>"
+            + "<taskListRef><name>task6ListRefName</name></taskListRef>"
+            + "<TaskArray><name>task7ArrayName</name></TaskArray>"
+            + "<TaskArray><name>task8ArrayName</name></TaskArray>"
+            + "<taskArrayRef><name>task8ArrayRefName</name></taskArrayRef>"
+            + "<taskArrayRef><name>task9ArrayRefName</name></taskArrayRef>"
+            + "</tasks>";
     TasksContainer container = new TasksContainer();
     container.setTask1(new Task("task1Name"));
-    container.setTask2(new Task("task2Name"));
+    container.setTask2Ref(new Task("task2Name"));
+    container.setTaskList(Arrays.asList(new Task("task3ListName"), new Task("task4ListName")));
+    container.setTaskListRef(
+        Arrays.asList(new Task("task5ListRefName"), new Task("task6ListRefName")));
+    container.setTaskArray(new ITask[] {new Task("task7ArrayName"), new Task("task8ArrayName")});
+    container.setTaskArrayRef(
+        new ITask[] {new Task("task8ArrayRefName"), new Task("task9ArrayRefName")});
 
     String result = mapper.write(container);
+
     assertEquals(XML, result);
     assertEquals(result, mapper.write(mapper.read(mapper.write(container))));
   }

--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmlelementref/interfaces/TasksContainer.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmlelementref/interfaces/TasksContainer.java
@@ -16,6 +16,7 @@
 
 package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmlelementref.interfaces;
 
+import java.util.List;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementRef;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -29,7 +30,19 @@ public class TasksContainer {
   private ITask task1;
 
   @XmlElementRef(name = "Task2", type = Task.class)
-  private ITask task2;
+  private ITask task2Ref;
+
+  @XmlElement(name = "TaskList", type = Task.class)
+  private List<ITask> taskList;
+
+  @XmlElementRef(name = "TaskListRef", type = Task.class)
+  private List<ITask> taskListRef;
+
+  @XmlElement(name = "TaskArray", type = Task.class)
+  private ITask[] taskArray;
+
+  @XmlElementRef(name = "TaskArrayRef", type = Task.class)
+  private ITask[] taskArrayRef;
 
   public ITask getTask1() {
     return task1;
@@ -39,11 +52,43 @@ public class TasksContainer {
     this.task1 = task1;
   }
 
-  public ITask getTask2() {
-    return task2;
+  public ITask getTask2Ref() {
+    return task2Ref;
   }
 
-  public void setTask2(ITask task2) {
-    this.task2 = task2;
+  public void setTask2Ref(ITask task2) {
+    this.task2Ref = task2;
+  }
+
+  public List<ITask> getTaskList() {
+    return taskList;
+  }
+
+  public void setTaskList(List<ITask> taskList) {
+    this.taskList = taskList;
+  }
+
+  public List<ITask> getTaskListRef() {
+    return taskListRef;
+  }
+
+  public void setTaskListRef(List<ITask> taskListRef) {
+    this.taskListRef = taskListRef;
+  }
+
+  public ITask[] getTaskArray() {
+    return taskArray;
+  }
+
+  public void setTaskArray(ITask[] taskArray) {
+    this.taskArray = taskArray;
+  }
+
+  public ITask[] getTaskArrayRef() {
+    return taskArrayRef;
+  }
+
+  public void setTaskArrayRef(ITask[] taskArrayRef) {
+    this.taskArrayRef = taskArrayRef;
   }
 }


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-5668

Further to #87 this PR completes support for "iterables" and arrays now covered.