### PR TITLE
KOGITO-5701: Failing test for XML attribute handled by XMLAdapter

### DIFF
--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/attribute/AttributeAdapterTest.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/attribute/AttributeAdapterTest.java
@@ -1,0 +1,36 @@
+package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.attribute;
+
+import javax.xml.stream.XMLStreamException;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Test;
+import org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.MyCustomBean;
+import org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.MyCustomBean2;
+import org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.MyTestBean;
+import org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.MyTestBeanTest;
+import org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.MyTestBean_XMLMapperImpl;
+
+import static org.junit.Assert.assertEquals;
+
+@J2clTestInput(MyTestBeanTest.class)
+public class AttributeAdapterTest {
+
+    private static final String XML =
+            "<?xml version='1.0' encoding='UTF-8'?><BeanWithAttribute value='test string'></BeanWithAttribute>";
+    private static final String ATTRIBUTE_VALUE = "test value";
+
+    BeanWithAttribute_XMLMapperImpl mapper = BeanWithAttribute_XMLMapperImpl.INSTANCE;
+
+    @Test
+    public void testSerializeValue() throws XMLStreamException {
+        BeanWithAttribute test = new BeanWithAttribute();
+        test.setValue(new AttributeObject(ATTRIBUTE_VALUE));
+        assertEquals(XML, mapper.write(test));
+    }
+
+    @Test
+    public void testDeserializeValue() throws XMLStreamException {
+        BeanWithAttribute test = mapper.read(XML);
+        assertEquals(ATTRIBUTE_VALUE, test.getValue().getValue());
+    }
+}

--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/attribute/AttributeObject.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/attribute/AttributeObject.java
@@ -1,0 +1,39 @@
+package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.attribute;
+
+import java.util.Objects;
+
+public class AttributeObject {
+
+    private String value;
+
+    public AttributeObject() {}
+
+    public AttributeObject(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AttributeObject)) {
+            return false;
+        }
+        AttributeObject that = (AttributeObject) o;
+        return Objects.equals(getValue(), that.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+}

--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/attribute/BeanWithAttribute.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/attribute/BeanWithAttribute.java
@@ -1,0 +1,47 @@
+package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.attribute;
+
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import org.treblereel.gwt.xml.mapper.api.annotation.XMLMapper;
+
+@XMLMapper
+public class BeanWithAttribute {
+
+    @XmlAttribute
+    @XmlJavaTypeAdapter(BeanWithAttributeAdapter.class)
+    private AttributeObject value;
+
+    public BeanWithAttribute() {}
+
+    public BeanWithAttribute(AttributeObject value) {
+        this.value = value;
+    }
+
+    public AttributeObject getValue() {
+        return value;
+    }
+
+    public void setValue(AttributeObject value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BeanWithAttribute)) {
+            return false;
+        }
+        BeanWithAttribute that = (BeanWithAttribute) o;
+        return Objects.equals(getValue(), that.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+}

--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/attribute/BeanWithAttributeAdapter.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/attribute/BeanWithAttributeAdapter.java
@@ -1,0 +1,16 @@
+package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.attribute;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+public class BeanWithAttributeAdapter extends XmlAdapter<String, AttributeObject> {
+
+    @Override
+    public AttributeObject unmarshal(String v) throws Exception {
+        return new AttributeObject(v);
+    }
+
+    @Override
+    public String marshal(AttributeObject v) throws Exception {
+        return v.getValue();
+    }
+}


### PR DESCRIPTION
Hi @treblereel,

XMLAdapter is work only for node elements now, when I tried it for XMLAttributes, the annotation is ignored and field saved to XML as element.

This PR contains a test. When I execute it I am getting this result:

```
Results :

Failed tests:   testSerializeValue(org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.attribute.AttributeAdapterTest): expected:<...?><BeanWithAttribute[ value='test string']></BeanWithAttribute...> but was:<...?><BeanWithAttribute[><value>test value</value]></BeanWithAttribute...>

Tests in error: 
  testDeserializeValue(org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.attribute.AttributeAdapterTest): java.lang.UnsupportedOperationException
```