### PR TITLE
KOGITO-5702: t is not possible to use interface as field with XmlAdapter

### DIFF
--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/AdapterForInterfaceTest.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/AdapterForInterfaceTest.java
@@ -1,0 +1,39 @@
+package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.generic;
+
+import javax.xml.stream.XMLStreamException;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Test;
+import org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.MyTestBeanTest;
+
+import static org.junit.Assert.assertEquals;
+
+@J2clTestInput(MyTestBeanTest.class)
+public class AdapterForInterfaceTest {
+
+    private static final String XML =
+            "<?xml version='1.0' encoding='UTF-8'?><RootBean><bean value=\"testValue\"/></RootBean>";
+    private static final String TEST_VALUE = "testValue";
+
+    private RootBean_XMLMapperImpl mapper = RootBean_XMLMapperImpl.INSTANCE;
+
+    @Test
+    public void testSerializeValue() throws XMLStreamException {
+        RootBean test = new RootBean();
+
+        ValueInterfaceImplementation interfaceImplementation = new ValueInterfaceImplementation();
+        interfaceImplementation.setValue(TEST_VALUE);
+        Bean bean1 = new Bean();
+        bean1.setValue(interfaceImplementation);
+        test.setBean(bean1);
+
+        assertEquals(XML, mapper.write(test));
+    }
+
+    @Test
+    public void testDeserializeValue() throws XMLStreamException {
+        RootBean test = mapper.read(XML);
+
+        assertEquals(TEST_VALUE, test.getBean().getValue().getValue());
+    }
+}

--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/Bean.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/Bean.java
@@ -1,0 +1,55 @@
+package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.generic;
+
+import java.util.Objects;
+
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlJavaTypeAdapter(InterfaceBeanAdapter.class)
+public class Bean {
+
+    private ValueInterface value;
+
+    public Bean() {
+    }
+
+    public Bean(BeanModel model) {
+        value = new ValueInterface() {
+            String value;
+
+            @Override
+            public String getValue() {
+                return value;
+            }
+
+            @Override
+            public void setValue(String value) {
+                this.value = value;
+            }
+        };
+    }
+
+    public ValueInterface getValue() {
+        return value;
+    }
+
+    public void setValue(ValueInterface value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Bean)) {
+            return false;
+        }
+        Bean bean = (Bean) o;
+        return Objects.equals(getValue(), bean.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+}

--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/BeanModel.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/BeanModel.java
@@ -1,0 +1,43 @@
+package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.generic;
+
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+public class BeanModel {
+
+    @XmlAttribute
+    private String value;
+
+    public BeanModel() {
+    }
+
+    public BeanModel(Bean bean) {
+        this.value = bean.getValue().getValue();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BeanModel)) {
+            return false;
+        }
+        BeanModel beanModel = (BeanModel) o;
+        return Objects.equals(getValue(), beanModel.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+}

--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/InterfaceBeanAdapter.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/InterfaceBeanAdapter.java
@@ -1,0 +1,16 @@
+package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.generic;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+public class InterfaceBeanAdapter extends XmlAdapter<BeanModel, Bean> {
+
+    @Override
+    public Bean unmarshal(BeanModel model) throws Exception {
+        return new Bean(model);
+    }
+
+    @Override
+    public BeanModel marshal(Bean bean) throws Exception {
+        return new BeanModel(bean);
+    }
+}

--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/RootBean.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/RootBean.java
@@ -1,0 +1,36 @@
+package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.generic;
+
+import java.util.Objects;
+
+import org.treblereel.gwt.xml.mapper.api.annotation.XMLMapper;
+
+@XMLMapper
+public class RootBean {
+
+    private Bean bean;
+
+    public Bean getBean() {
+        return bean;
+    }
+
+    public void setBean(Bean bean) {
+        this.bean = bean;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RootBean)) {
+            return false;
+        }
+        RootBean rootBean = (RootBean) o;
+        return Objects.equals(getBean(), rootBean.getBean());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getBean());
+    }
+}

--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/ValueInterface.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/ValueInterface.java
@@ -1,0 +1,8 @@
+package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.generic;
+
+public interface ValueInterface {
+
+    String getValue();
+
+    void setValue(String value);
+}

--- a/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/ValueInterfaceImplementation.java
+++ b/tests/jre/src/test/java/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/ValueInterfaceImplementation.java
@@ -1,0 +1,16 @@
+package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.generic;
+
+public class ValueInterfaceImplementation implements ValueInterface {
+
+    private String value;
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public void setValue(String value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
It is needed to use some generic types in some cases and replace it by real values in XmlAdapter.

If I am doing it I am getting this error:

```
[ERROR] /Volumes/Workspace/treblereel/mapper-xml/tests/jre/target/generated-test-sources/test-annotations/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/BeanBeanXMLSerializerImpl.java:[33,101] cannot find symbol
  symbol:   class ValueInterfaceBeanXMLSerializerImpl
  location: package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.generic
[ERROR] /Volumes/Workspace/treblereel/mapper-xml/tests/jre/target/generated-test-sources/test-annotations/org/treblereel/gwt/xml/mapper/client/tests/annotations/xmladapter/generic/BeanBeanXMLDeserializerImpl.java:[36,101] cannot find symbol
  symbol:   class ValueInterfaceBeanXMLDeserializerImpl
  location: package org.treblereel.gwt.xml.mapper.client.tests.annotations.xmladapter.generic
```

This PR contains full reproducer.